### PR TITLE
Allow skipping loading via SKIP_SIGNAL_SECRET_SERVICE

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -71,6 +71,12 @@ eval_export() {
     eval export $to_export
 }
 
+if [ -n SKIP_SIGNAL_SECRET_SERVICE ]; then
+    echo "Skipping secrets fetch with chamber as SKIP_SIGNAL_SECRET_SERVICE was set"
+    echo "Starting $@..."
+    exec "$@"
+fi
+
 # Get list of ENV variables injected by Docker
 echo "Getting ENV variables..."
 original_variables=$(export | cut -f2 -d ' ')


### PR DESCRIPTION
This means that we can still build the entrypoint into the image, while not running the code in development environments where all secrets are explicitly provided.

`exec` replaces the current process so is safe to use in the middle of a script.

_I should add this to the README as well_