### PR TITLE
cb: Use chamber export rather than chamber env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine:3.11
-
-ADD ./init.sh /
-
-RUN chmod +x /init.sh && /init.sh

--- a/Dockerfile.al2
+++ b/Dockerfile.al2
@@ -1,0 +1,15 @@
+FROM amazonlinux:2
+
+ENV SECRET_SERVICES="global signal"
+
+ENV ROLLBAR_TOKEN=SECRET
+ENV CIRCLECI_TOKEN=SECRET
+ENV OTHER_ENV_VAR=test_var
+
+COPY ./init.sh /
+
+RUN chmod +x /init.sh && /init.sh
+
+COPY ./test-command.sh /test-command.sh
+
+CMD ["/init.sh", "/test-command.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,15 @@
+FROM alpine:3.12
+
+ENV SECRET_SERVICES="global signal"
+
+ENV ROLLBAR_TOKEN=SECRET
+ENV CIRCLECI_TOKEN=SECRET
+ENV OTHER_ENV_VAR=test_var
+
+COPY ./init.sh /
+
+RUN chmod +x /init.sh && /init.sh
+
+COPY ./test-command.sh /test-command.sh
+
+CMD ["/init.sh", "/test-command.sh"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,20 @@
+FROM debian:stable-slim
+
+ENV SECRET_SERVICES="global signal"
+
+ENV ROLLBAR_TOKEN=SECRET
+ENV CIRCLECI_TOKEN=SECRET
+ENV OTHER_ENV_VAR=test_var
+
+RUN apt-get update -yy && apt-get install --no-install-recommends -yy \
+    curl \
+    ca-certificates \
+    && update-ca-certificates
+
+COPY ./init.sh /
+
+RUN chmod +x /init.sh && /init.sh
+
+COPY ./test-command.sh /test-command.sh
+
+CMD ["/init.sh", "/test-command.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY:
+test:
+	@echo "Running amazon linux 2..."
+	@docker build . -f Dockerfile.al2 -t signal-secret-service-al2
+	@docker run \
+		-e AWS_PROFILE=signal-prod \
+		-e ROLLBAR_TOKEN=SECRET \
+		-e CIRCLECI_TOKEN=SECRET \
+		-e OTHER_ENV_VAR=test_var \
+		-v $$HOME/.aws:/root/.aws \
+		--rm \
+		signal-secret-service-al2
+	@echo
+
+	@echo "Running alpine..."
+	@docker build . -f Dockerfile.alpine -t signal-secret-service-alpine
+	@docker run \
+		-e AWS_PROFILE=signal-prod \
+		-e ROLLBAR_TOKEN=SECRET \
+		-e CIRCLECI_TOKEN=SECRET \
+		-e OTHER_ENV_VAR=test_var \
+		-v $$HOME/.aws:/root/.aws \
+		--rm \
+		signal-secret-service-alpine
+	@echo
+
+	@echo "Running debian"
+	@docker build . -f Dockerfile.debian -t signal-secret-service-debian
+	@docker run \
+		-e AWS_PROFILE=signal-prod \
+		-e ROLLBAR_TOKEN=SECRET \
+		-e CIRCLECI_TOKEN=SECRET \
+		-e OTHER_ENV_VAR=test_var \
+		-v $$HOME/.aws:/root/.aws \
+		--rm \
+		signal-secret-service-debian

--- a/README.md
+++ b/README.md
@@ -207,4 +207,6 @@ aws ssm get-parameters-by-path --path /service/secret_key --with-decryption | jq
 
 ## Local testing
 
-Run `docker build -t test .` to test build `init.sh` with alpine. You can change the base image in `Dockerfile`.
+Run `make test` to test build `init.sh` with amazon linux 2/alpine/debian base images.
+
+This outputs three environment variables with secrets.

--- a/init.sh
+++ b/init.sh
@@ -78,9 +78,7 @@ original_variables=$(export | cut -f2 -d ' ')
 # Call chamber with services from ENV $SECRET_SERVICES and export decrypted ENV variables
 echo "Fetching ENV secrets with chamber for systems $SECRET_SERVICES..."
 
-# We have to loop through $SECRET_SERVICES because 'chamber env' doesn't support
-# multiple services
-chamber_env=$(for s in $SECRET_SERVICES ; do /chamber env $s || rc=$? ; done ; exit $rc)
+chamber_env=$(/chamber export --format dotenv $SECRET_SERVICES)
 chamber_result=$?
 
 if [ $chamber_result != 0 ]; then
@@ -91,12 +89,12 @@ if [ $chamber_result != 0 ]; then
     fi
 fi
 
-# We want to remove 'export' from the env output and also convert - into _ for env names
-to_secrets=$(echo $chamber_env | sed 's/export //g' | for e in $(cat -) ; do echo $e | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
+# We want to remove convert - into _ for env names
+to_secrets=$(echo $chamber_env | for e in $(cat -) ; do echo $e | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
 eval_export $to_secrets
 
 # Perform overrides
-to_override=$(for k in $keys ; do for v in $original_variables ; do echo $v |grep ^$k |grep -v SECRET ; done ; done)
+to_override=$(for k in $keys ; do for v in $original_variables ; do echo $v | grep ^$k |grep -v SECRET ; done ; done)
 if [ ! -z "$to_override" -a "$to_override" != " " ]; then
     echo "Applying ENV overrides..."
     eval_export $to_override
@@ -104,7 +102,7 @@ fi
 
 # Perform variable extrapolation
 secret_keys=$(for v in $to_secrets ; do echo $v | awk -F '=' '{print $1}' ; done)
-to_extrapolate=$(for k in $secret_keys ; do env |grep "\$$k" ; done | uniq | sed 's/\(=[[:blank:]]*\)\(.*\)/\1"\2"/')
+to_extrapolate=$(for k in $secret_keys ; do env | grep "\$$k" ; done | uniq | sed 's/\(=[[:blank:]]*\)\(.*\)/\1"\2"/')
 if [ ! -z "$to_extrapolate" -a "$to_extrapolate" != " " ]; then
     echo "Applying ENV extrapolation..."
     eval_export $to_extrapolate

--- a/test-command.sh
+++ b/test-command.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo
+echo "Result environment variables:"
+echo
+
+env | grep -E "ROLLBAR_TOKEN|CIRCLECI_TOKEN|OTHER_ENV_VAR"


### PR DESCRIPTION
This supports multiple services - and likely avoids rate limits when accessing SSM.

For context, we occasionally see errors on batch processing when using secrets with SSM - there are no logs here so my assumption is we're hitting some rate limit or timeout.
